### PR TITLE
fix: handle build module import failure and copy prisma files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV NODE_ENV=production
 COPY ./package.json server.js /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build
+COPY --from=build-env /app/node_modules/.prisma /app/node_modules/.prisma
 COPY --from=build-env /app/prisma /app/prisma
 WORKDIR /app
 RUN npx prisma generate

--- a/server.js
+++ b/server.js
@@ -41,7 +41,16 @@ if (DEVELOPMENT) {
   );
   app.use(morgan("tiny"));
   app.use(express.static("build/client", { maxAge: "1h" }));
-  app.use(await import(BUILD_PATH).then((mod) => mod.app));
+  
+  try {
+    const buildModule = await import(BUILD_PATH);
+    app.use(buildModule.app);
+  } catch (error) {
+    console.error("Failed to import build module:", error);
+    app.use((req, res) => {
+      res.status(500).send("Server configuration error");
+    });
+  }
 }
 
 const HOST = DEVELOPMENT ? "localhost" : "0.0.0.0";


### PR DESCRIPTION
Add error handling for build module import to prevent server crashes Copy .prisma files from build-env to ensure prisma client works correctly