### PR TITLE
fix: use APP_URL instead of DOMAIN for QR code generation

### DIFF
--- a/app/presentation/attendees/api/create-attendee.action.ts
+++ b/app/presentation/attendees/api/create-attendee.action.ts
@@ -170,7 +170,7 @@ export const createAttendeeAction = async ({
     }
 
     const qrCodeUrl = await QRCode.toDataURL(
-      `${process.env.DOMAIN}/verificar-registro/${finalRegistrations.qrCode}`,
+      `${process.env.APP_URL}/verificar-registro/${finalRegistrations.qrCode}`,
     );
 
     console.log(qrCodeUrl);


### PR DESCRIPTION
The environment variable DOMAIN was replaced with APP_URL to ensure consistency with our configuration standards and avoid potential confusion with other domain-related variables.